### PR TITLE
Fix a crash in TjGetErrorStr

### DIFF
--- a/Quamotion.TurboJpegWrapper.Tests/TJCompressorTests.cs
+++ b/Quamotion.TurboJpegWrapper.Tests/TJCompressorTests.cs
@@ -115,6 +115,12 @@ namespace TurboJpegWrapper.Tests
             }
         }
 
+        [Fact]
+        public void CompressInvalidIntPtr()
+        {
+            Assert.Throws<TJException>(() => this.compressor.Compress(IntPtr.Zero, 0, 0, 0, PixelFormat.Format32bppArgb, TJSubsamplingOption.Gray, 0, TJFlags.None));
+        }
+
         [Theory]
         [CombinatorialData]
         public void CompressByteArray(

--- a/Quamotion.TurboJpegWrapper/TJUtils.cs
+++ b/Quamotion.TurboJpegWrapper/TJUtils.cs
@@ -17,7 +17,7 @@ namespace TurboJpegWrapper
         /// <exception cref="TJException"> Throws if low level turbo jpeg function fails. </exception>
         public static void GetErrorAndThrow()
         {
-            var error = TurboJpegImport.TjGetErrorStr();
+            var error = Marshal.PtrToStringAnsi(TurboJpegImport.TjGetErrorStr());
             throw new TJException(error);
         }
 

--- a/Quamotion.TurboJpegWrapper/TurboJpegImport.cs
+++ b/Quamotion.TurboJpegWrapper/TurboJpegImport.cs
@@ -535,9 +535,8 @@ namespace TurboJpegWrapper
         /// Returns a descriptive error message explaining why the last command failed.
         /// </summary>
         /// <returns>A descriptive error message explaining why the last command failed.</returns>
-        [DllImport(UnmanagedLibrary, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, EntryPoint = "tjGetErrorStr")]
-        [return: MarshalAs(UnmanagedType.LPStr)]
-        public static extern string TjGetErrorStr();
+        [DllImport(UnmanagedLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tjGetErrorStr")]
+        public static extern IntPtr TjGetErrorStr();
 
         [DllImport(UnmanagedLibrary, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tjDecompressHeader3")]
         private static extern int TjDecompressHeader3_x86(IntPtr handle, IntPtr jpegBuf, uint jpegSize, out int width, out int height, out int jpegSubsamp, out int jpegColorspace);


### PR DESCRIPTION
TjGetErrorStr returns a fixed string, which should not be free'd by the caller. Marshalling a return value as a string would cause the CLR to free the string, causing memory corruption.

Fixes #17 