### PR TITLE
Run tests inside a Docker container

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -232,7 +232,7 @@ jobs:
   - script: |
       sudo add-apt-repository ppa:quamotion/ppa
       sudo apt-get update
-      sudo apt-get install -y libgdiplus libcurl4
+      sudo apt-get install -y libc6-dev libgdiplus libcurl4
     displayName: Install libgdiplus, libcurl
   - script: |
       dotnet restore


### PR DESCRIPTION
Somehow the ubuntu.16.04 image broke *again*, so let's just call it a day and build inside a Docker container instead.