### PR TITLE
TJCompressor.Compress: Add TJPixelFormat overload

### DIFF
--- a/Quamotion.TurboJpegWrapper/TJCompressor.cs
+++ b/Quamotion.TurboJpegWrapper/TJCompressor.cs
@@ -343,13 +343,60 @@ namespace TurboJpegWrapper
         /// </exception>
         public unsafe Span<byte> Compress(Span<byte> srcBuf, Span<byte> destBuf, int stride, int width, int height, PixelFormat pixelFormat, TJSubsamplingOption subSamp, int quality, TJFlags flags)
         {
+            var tjPixelFormat = TJUtils.ConvertPixelFormat(pixelFormat);
+
+            return this.Compress(srcBuf, destBuf, stride, width, height, tjPixelFormat, subSamp, quality, flags);
+        }
+
+        /// <summary>
+        /// Compresses input image to the jpeg format with specified quality.
+        /// </summary>
+        /// <param name="srcBuf">
+        /// Image buffer containing RGB, grayscale, or CMYK pixels to be compressed.
+        /// This buffer is not modified.
+        /// </param>
+        /// <param name="destBuf">
+        /// A <see cref="byte"/> array containing the compressed image.
+        /// </param>
+        /// <param name="stride">
+        /// Bytes per line in the source image.
+        /// Normally, this should be <c>width * BytesPerPixel</c> if the image is unpadded,
+        /// or <c>TJPAD(width * BytesPerPixel</c> if each line of the image
+        /// is padded to the nearest 32-bit boundary, as is the case for Windows bitmaps.
+        /// You can also be clever and use this parameter to skip lines, etc.
+        /// Setting this parameter to 0 is the equivalent of setting it to
+        /// <c>width * BytesPerPixel</c>.
+        /// </param>
+        /// <param name="width">Width (in pixels) of the source image.</param>
+        /// <param name="height">Height (in pixels) of the source image.</param>
+        /// <param name="pixelFormat">Pixel format of the source image (see <see cref="PixelFormat"/> "Pixel formats").</param>
+        /// <param name="subSamp">
+        /// The level of chrominance subsampling to be used when
+        /// generating the JPEG image (see <see cref="TJSubsamplingOption"/> "Chrominance subsampling options".)
+        /// </param>
+        /// <param name="quality">The image quality of the generated JPEG image (1 = worst, 100 = best).</param>
+        /// <param name="flags">The bitwise OR of one or more of the <see cref="TJFlags"/> "flags".</param>
+        /// <returns>
+        /// A <see cref="Span{T}"/> which is a slice of <paramref name="destBuf"/> which holds the compressed image.
+        /// </returns>
+        /// <exception cref="TJException">
+        /// Throws if compress function failed.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">Object is disposed and can not be used anymore.</exception>
+        /// <exception cref="NotSupportedException">
+        /// Some parameters' values are incompatible:
+        /// <list type="bullet">
+        /// <item><description>Subsampling not equals to <see cref="TJSubsamplingOption.Gray"/> and pixel format <see cref="TJPixelFormat.Gray"/></description></item>
+        /// </list>
+        /// </exception>
+        public unsafe Span<byte> Compress(Span<byte> srcBuf, Span<byte> destBuf, int stride, int width, int height, TJPixelFormat pixelFormat, TJSubsamplingOption subSamp, int quality, TJFlags flags)
+        {
             if (this.isDisposed)
             {
                 throw new ObjectDisposedException(nameof(TJCompressor));
             }
 
-            var tjPixelFormat = TJUtils.ConvertPixelFormat(pixelFormat);
-            CheckOptionsCompatibilityAndThrow(subSamp, tjPixelFormat);
+            CheckOptionsCompatibilityAndThrow(subSamp, pixelFormat);
 
             ulong destBufSize = (ulong)destBuf.Length;
 
@@ -364,7 +411,7 @@ namespace TurboJpegWrapper
                     width,
                     stride,
                     height,
-                    (int)tjPixelFormat,
+                    (int)pixelFormat,
                     ref destBufPtr2,
                     ref destBufSize,
                     (int)subSamp,


### PR DESCRIPTION
Add an overload to TJCompressor.Compress which allows you to specify the native pixel format using the TJPixelFormat enum.