### PR TITLE
Bump dependencies

### DIFF
--- a/Quamotion.TurboJpegWrapper/Quamotion.TurboJpegWrapper.csproj
+++ b/Quamotion.TurboJpegWrapper/Quamotion.TurboJpegWrapper.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net45'">
-    <PackageReference Include="System.Drawing.Common" Version="4.6.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
Updating System.Drawing.Common fixes an issue with libgdiplus not being loaded correctly on Linux.
Dependency housekeeping.