### PR TITLE
Add support for turbojpeg 1.2

### DIFF
--- a/Quamotion.TurboJpegWrapper.Tests/TJCompressorTests.cs
+++ b/Quamotion.TurboJpegWrapper.Tests/TJCompressorTests.cs
@@ -43,7 +43,6 @@ namespace TurboJpegWrapper.Tests
         public void CompressBitmap(
             [CombinatorialValues(
             TJSubsamplingOption.Gray,
-            TJSubsamplingOption.Chrominance411,
             TJSubsamplingOption.Chrominance420,
             TJSubsamplingOption.Chrominance440,
             TJSubsamplingOption.Chrominance422,
@@ -80,7 +79,6 @@ namespace TurboJpegWrapper.Tests
         public void CompressIntPtr(
             [CombinatorialValues(
             TJSubsamplingOption.Gray,
-            TJSubsamplingOption.Chrominance411,
             TJSubsamplingOption.Chrominance420,
             TJSubsamplingOption.Chrominance440,
             TJSubsamplingOption.Chrominance422,
@@ -126,7 +124,6 @@ namespace TurboJpegWrapper.Tests
         public void CompressByteArray(
             [CombinatorialValues(
             TJSubsamplingOption.Gray,
-            TJSubsamplingOption.Chrominance411,
             TJSubsamplingOption.Chrominance420,
             TJSubsamplingOption.Chrominance440,
             TJSubsamplingOption.Chrominance422,
@@ -169,7 +166,6 @@ namespace TurboJpegWrapper.Tests
         public void CompressByteArrayToByteArray(
             [CombinatorialValues(
             TJSubsamplingOption.Gray,
-            TJSubsamplingOption.Chrominance411,
             TJSubsamplingOption.Chrominance420,
             TJSubsamplingOption.Chrominance440,
             TJSubsamplingOption.Chrominance422,
@@ -213,7 +209,6 @@ namespace TurboJpegWrapper.Tests
         public unsafe void CompressSpanToSpan(
             [CombinatorialValues(
             TJSubsamplingOption.Gray,
-            TJSubsamplingOption.Chrominance411,
             TJSubsamplingOption.Chrominance420,
             TJSubsamplingOption.Chrominance440,
             TJSubsamplingOption.Chrominance422,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -187,8 +187,8 @@ jobs:
       sudo yum install -y dotnet-sdk-6.0
     displayName: Install .NET 6.0 SDK
   - script: |
-      sudo yum-config-manager -y --add-repo https://download.opensuse.org/repositories/home:/qmfrederik/CentOS_7/home:qmfrederik.repo
-      sudo yum install -y libgdiplus libturbojpeg
+      sudo yum-config-manager -y --add-repo https://download.mono-project.com/repo/centos7-stable.repo
+      sudo yum install -y libgdiplus turbojpeg
     displayName: Install libjpeg-turbo native binaries
   - script: |
       dotnet restore


### PR DESCRIPTION
CentOS 7 ships with turbojpeg 1.2, which:
- Does not support 4:1:1 chrominance ([added in 1.4](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/ChangeLog.md#1390-14-beta1))
- Does not support `tjDecompressHeader3` ([added in 1.4](https://github.com/libjpeg-turbo/libjpeg-turbo/commit/cd7c3e6672cce3779450c6dd10d0d70b0c2278b2)